### PR TITLE
Add basic validation to version number input

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -4,6 +4,14 @@ if [ -z "$1" ]; then
     echo "Usage: ./build-release <version-number>"
     exit
 fi
+
+if [[ ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Version number looks incorrect"
+    exit 1
+else
+    echo "Creating release artifacts with version number: $1"
+fi
+
 version="$1"
 
 package="github.com/18f/watchtower"


### PR DESCRIPTION
In order to prevent the build script from being accidentally run with
an invalid version number parameter, validate the input against a basic
regex that checks for three integers separated by the dot (.) character.
This will ensure that Watchtower release binaries all follow the same,
consistent pattern with every release.
