### PR TITLE
fix golanci lint findings

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,30 @@
+---
+name: golangci-lint
+on:
+  push:
+    paths:
+      - "go.sum"
+      - "go.mod"
+      - "**.go"
+      - ".github/workflows/golangci-lint.yml"
+      - ".golangci.yml"
+  pull_request:
+    permissions:
+      contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,4 +31,4 @@ linters-settings:
     min-complexity: 10
 
   gosimple:  # Enabled by default
-    go: "1.17"
+    go: "1.18"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,8 +18,6 @@ linters:
     - revive  # Drop-in replacement of golint
     - tenv  # Detects using os.Setenv instead of t.Setenv since Go1.17
     - unconvert  # Remove unnecessary type conversions
-  disable:
-    - typecheck
 
 linters-settings:
   errcheck:  # Enabled by default

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,36 @@
+---
+output:
+  sort-results: true
+linters:
+  # List of *non-default* linters to enable
+  enable:
+    - asciicheck  # Check that your code does not contain non-ASCII identifiers
+    - bidichk  # Checks for dangerous unicode character sequences
+    - bodyclose  # Checks whether HTTP response body is closed successfully
+    - errorlint  # Checks for error wrapping scheme issues in Go >= 1.13
+    - gocognit  # Computes and checks the cognitive complexity of functions
+    - gocritic  # Checks for bugs, performance and style issues
+    - gofmt  # Checks whether code was gofmt-ed. Uses '-s' simplification option
+    - gomnd  # An analyzer to detect magic numbers
+    - gosec  # Inspects source code for security problems
+    - ifshort  # Checks that your code uses short syntax for if-statements
+    - misspell  # Finds commonly misspelled English words in comments
+    - revive  # Drop-in replacement of golint
+    - tenv  # Detects using os.Setenv instead of t.Setenv since Go1.17
+    - unconvert  # Remove unnecessary type conversions
+  disable:
+    - typecheck
+
+linters-settings:
+  errcheck:  # Enabled by default
+    # report not checking of errors in type assertions: `a := b.(MyStruct)`;
+    check-type-assertions: true
+    # report assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    check-blank: true
+
+  gocognit:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 10
+
+  gosimple:  # Enabled by default
+    go: "1.17"

--- a/drift_detector.go
+++ b/drift_detector.go
@@ -95,18 +95,9 @@ func (detector *Detector) Validate() {
 	waitgroup.Wait()
 }
 
-// ValidateAppRoutes performs CF App Route resource validation
-func (detector *Detector) validateAppRoutes(wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	var cache = &detector.cache
-
-	if !cache.isValid() {
-		log.Println("Invalid cache detected. Skipping routes check.")
-		failedRouteChecks.Inc()
-		return
-	}
-
+// getMissingRoutes will return a slice of strings representing missing routes in the form
+// <app_name>:<app_hostname>.<app_domain>
+func (detector *Detector) getMissingRoutes() []string {
 	var missingRoutes []string
 	for _, app := range detector.config.Apps {
 		for _, route := range app.Routes {
@@ -117,9 +108,15 @@ func (detector *Detector) validateAppRoutes(wg *sync.WaitGroup) {
 		}
 	}
 
+	return missingRoutes
+}
+
+// getUnknownRoutes will return a slice of strings representing unknown routes in the form
+// <app_name>:<app_hostname>.<app_domain>
+func (detector *Detector) getUnknownRoutes() []string {
 	var unknownRoutes []string
-	for _, mapping := range cache.RouteMappings.routeMappings {
-		app, route, domainName, err := cache.getMappingResources(mapping.Guid)
+	for _, mapping := range detector.cache.RouteMappings.routeMappings {
+		app, route, domainName, err := detector.cache.getMappingResources(mapping.Guid)
 		if err != nil {
 			continue
 		}
@@ -136,6 +133,24 @@ func (detector *Detector) validateAppRoutes(wg *sync.WaitGroup) {
 			unknownRoutes = append(unknownRoutes, app.Name+":"+routeURL)
 		}
 	}
+
+	return unknownRoutes
+}
+
+// ValidateAppRoutes performs CF App Route resource validation
+func (detector *Detector) validateAppRoutes(wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	var cache = &detector.cache
+
+	if !cache.isValid() {
+		log.Println("Invalid cache detected. Skipping routes check.")
+		failedRouteChecks.Inc()
+		return
+	}
+
+	missingRoutes := detector.getMissingRoutes()
+	unknownRoutes := detector.getUnknownRoutes()
 
 	if len(unknownRoutes) != 0 {
 		sort.Strings(unknownRoutes)

--- a/drift_detector.go
+++ b/drift_detector.go
@@ -161,7 +161,7 @@ func (detector *Detector) validateApps(wg *sync.WaitGroup) {
 	}
 
 	var unknownApps []string
-	for name, _ := range detector.cache.Apps.nameMap {
+	for name := range detector.cache.Apps.nameMap {
 		if _, ok := detector.config.Apps[name]; !ok {
 			unknownApps = append(unknownApps, name)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/18f/watchtower
 
-go 1.17
+go 1.18
 
 require (
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20211107003623-1d25c34ce45b

--- a/main.go
+++ b/main.go
@@ -140,7 +140,6 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Fatalf("Error writing response. Err: %s", err)
 	}
-	return
 }
 
 func main() {

--- a/resource_cache.go
+++ b/resource_cache.go
@@ -66,12 +66,11 @@ func (cache *CFResourceCache) isValid() bool {
 func (cache *CFResourceCache) findRouteByURL(host, domain string) (cfclient.Route, bool) {
 	for _, route := range cache.Routes.routes {
 		if route.Host == host {
-			cfSharedDomain, ok1 := cache.SharedDomains.guidMap[route.DomainGuid]
-			cfPrivateDomain, ok2 := cache.Domains.guidMap[route.DomainGuid]
-			if !ok1 && !ok2 {
-				log.Printf("Domain lookup failed for GUID: %s", route.DomainGuid)
-				continue
-			}
+			// Look up the domain for this route
+			cfSharedDomain := cache.SharedDomains.guidMap[route.DomainGuid]
+			cfPrivateDomain := cache.Domains.guidMap[route.DomainGuid]
+
+			// Check if the route domain name is also a match - success case
 			if cfSharedDomain.Name == domain || cfPrivateDomain.Name == domain {
 				return route, true
 			}

--- a/resource_config.go
+++ b/resource_config.go
@@ -63,14 +63,16 @@ type SpaceEntry struct {
 // RouteEntry represents the allowed values for each entry under 'routes' within 'apps'
 type RouteEntry string
 
+const CFMaxRouteTokens = 2
+
 // Host extracts the hostname from the given Route
 func (r *RouteEntry) Host() string {
-	return strings.SplitN(string(*r), ".", 2)[0]
+	return strings.SplitN(string(*r), ".", CFMaxRouteTokens)[0]
 }
 
 // Domain extracts the domain from the given Route
 func (r *RouteEntry) Domain() string {
-	return strings.SplitN(string(*r), ".", 2)[1]
+	return strings.SplitN(string(*r), ".", CFMaxRouteTokens)[1]
 }
 
 // LoadResourceConfig reads config.yaml and parses it into a ResourceConfig. If

--- a/resource_config_test.go
+++ b/resource_config_test.go
@@ -30,7 +30,8 @@ spaces:
     - name: prod
       allow_ssh: false`
 
-func TestLoadResourceConfigAppsEnabled(t *testing.T) {
+// TestAppsEnabled ensures that the 'enabled' option within the 'apps' block is set correctly.
+func TestAppsEnabled(t *testing.T) {
 	conf := LoadResourceConfig([]byte(basicConfig))
 
 	if conf.Data.AppConfig.Enabled != true {
@@ -38,13 +39,21 @@ func TestLoadResourceConfigAppsEnabled(t *testing.T) {
 	}
 }
 
-func TestLoadResourceConfigAppNames(t *testing.T) {
+// TestAppsEnabled ensures that the 'enabled' option within the 'apps' block is set correctly.
+func TestNumberOfApps(t *testing.T) {
 	conf := LoadResourceConfig([]byte(basicConfig))
 
 	apps := conf.Data.AppConfig.Apps
 	if len(apps) != 4 {
 		t.Fatalf("Number of apps found was incorrect. Found: %d Details: %+v", len(apps), apps)
 	}
+}
+
+// TestAppNames tests the app names that are found for the given config.
+func TestAppNames(t *testing.T) {
+	conf := LoadResourceConfig([]byte(basicConfig))
+
+	apps := conf.Data.AppConfig.Apps
 
 	if app0Name, expected := apps[0].Name, "my-cool-app"; app0Name != expected {
 		t.Fatalf("%s name incorrect. Found: %s", expected, app0Name)
@@ -60,13 +69,11 @@ func TestLoadResourceConfigAppNames(t *testing.T) {
 	}
 }
 
-func TestLoadResourceConfigOptionalApp(t *testing.T) {
+// TestOptionalApp tests the 'optional' setting within the 'resources' block of 'apps'.
+func TestOptionalApp(t *testing.T) {
 	conf := LoadResourceConfig([]byte(basicConfig))
 
 	apps := conf.Data.AppConfig.Apps
-	if len(apps) != 4 {
-		t.Fatalf("Number of apps found was incorrect. Found: %d Details: %+v", len(apps), apps)
-	}
 
 	if app0 := apps[0]; app0.Optional != false {
 		t.Fatalf("%s optional incorrect", app0.Name)
@@ -82,13 +89,11 @@ func TestLoadResourceConfigOptionalApp(t *testing.T) {
 	}
 }
 
-func TestLoadResourceConfigAppRoutes(t *testing.T) {
+// TestNumberOfAppRoutes tests that the correct number of routes are found for the given config.
+func TestNumberOfAppRoutes(t *testing.T) {
 	conf := LoadResourceConfig([]byte(basicConfig))
 
 	apps := conf.Data.AppConfig.Apps
-	if len(apps) != 4 {
-		t.Fatalf("Number of apps found was incorrect. Found: %d Details: %+v", len(apps), apps)
-	}
 
 	// Validate route lengths for each app
 	if app1, app1Routes := apps[0].Name, apps[0].Routes; len(app1Routes) != 0 {
@@ -97,50 +102,76 @@ func TestLoadResourceConfigAppRoutes(t *testing.T) {
 	if app2, app2Routes := apps[1].Name, apps[1].Routes; len(app2Routes) != 0 {
 		t.Fatalf("Incorrect number of routes for %s. Details: %+v", app2, app2Routes)
 	}
-	app3 := apps[2]
-	routes := app3.Routes
-	if len(routes) != 1 {
-		t.Fatalf("Incorrect number of routes for %s. Details: %+v", app3.Name, routes)
+	if app3, app3Routes := apps[2].Name, apps[2].Routes; len(app3Routes) != 1 {
+		t.Fatalf("Incorrect number of routes for %s. Details: %+v", app3, app3Routes)
 	}
-	if routes[0] != "app-hostname.app.cloudfoundry" {
-		t.Fatalf("Incorrect route for app %s, found %s", app3.Name, routes[0])
+	if app4, app4Routes := apps[3].Name, apps[3].Routes; len(app4Routes) != 3 {
+		t.Fatalf("Incorrect number of routes for %s. Details: %+v", app4, app4Routes)
 	}
-
-	// Validate route details
-	route0 := routes[0]
-	if route0.Host() != "app-hostname" {
-		t.Fatalf("%s routes[0].Host incorrect. Found: %+v", app3.Name, route0)
-	}
-	if route0.Domain() != "app.cloudfoundry" {
-		t.Fatalf("%s routes[0].Domain incorrect. Found: %+v", app3.Name, route0)
-	}
-
-	app4 := apps[3]
-	routes = app4.Routes
-	if len(routes) != 3 {
-		t.Fatalf("Incorrect number of routes for %s. Details: %+v", app4.Name, routes)
-	}
-	if routes[0] != "hostname1.first.domain" {
-		t.Fatalf("Incorrect route1 for app %s, found %s", app4.Name, routes[0])
-	}
-	if routes[1] != "hostname2.first.domain" {
-		t.Fatalf("Incorrect route2 for app %s, found %s", app4.Name, routes[1])
-	}
-	if routes[2] != "hostname3.second.domain" {
-		t.Fatalf("Incorrect route3 for app %s, found %s", app4.Name, routes[1])
-	}
-
-	route1 := routes[1]
-	if route1.Host() != "hostname2" {
-		t.Fatalf("%s routes[1].Host incorrect. Found: %+v", app3.Name, route1)
-	}
-	if route1.Domain() != "first.domain" {
-		t.Fatalf("%s routes[1].Domain incorrect. Found: %+v", app3.Name, route1)
-	}
-
 }
 
-func TestLoadResourceConfigEnvVar(t *testing.T) {
+// TestAppRoutes tests that the correct route (hostname+domain) are found for the given config.
+func TestAppRoutes(t *testing.T) {
+	conf := LoadResourceConfig([]byte(basicConfig))
+
+	apps := conf.Data.AppConfig.Apps
+
+	if apps[2].Routes[0] != "app-hostname.app.cloudfoundry" {
+		t.Fatalf("Incorrect route for app %s, found %s", apps[2].Name, apps[2].Routes[0])
+	}
+	if apps[3].Routes[0] != "hostname1.first.domain" {
+		t.Fatalf("Incorrect route1 for app %s, found %s", apps[4].Name, apps[4].Routes[0])
+	}
+	if apps[3].Routes[1] != "hostname2.first.domain" {
+		t.Fatalf("Incorrect route2 for app %s, found %s", apps[4].Name, apps[4].Routes[1])
+	}
+	if apps[3].Routes[2] != "hostname3.second.domain" {
+		t.Fatalf("Incorrect route3 for app %s, found %s", apps[4].Name, apps[4].Routes[1])
+	}
+}
+
+// TestRouteHost tests that the RouteEntry.Host() method pulls the correct hostname from the app routes.
+func TestRouteHost(t *testing.T) {
+	conf := LoadResourceConfig([]byte(basicConfig))
+	apps := conf.Data.AppConfig.Apps
+	app3, app4 := apps[2], apps[3]
+
+	if host := app3.Routes[0].Host(); host != "app-hostname" {
+		t.Fatalf("%s routes[0].Host incorrect. Found: %+v", app3.Name, host)
+	}
+	if host := app4.Routes[0].Host(); host != "hostname1" {
+		t.Fatalf("%s routes[0].Host incorrect. Found: %+v", app4.Name, host)
+	}
+	if host := app4.Routes[1].Host(); host != "hostname2" {
+		t.Fatalf("%s routes[1].Host incorrect. Found: %+v", app4.Name, host)
+	}
+	if host := app4.Routes[2].Host(); host != "hostname3" {
+		t.Fatalf("%s routes[2].Host incorrect. Found: %+v", app4.Name, host)
+	}
+}
+
+// TestRouteDomain tests that the RouteEntry.Domain() method pulls the correct domain from the app routes.
+func TestRouteDomain(t *testing.T) {
+	conf := LoadResourceConfig([]byte(basicConfig))
+	apps := conf.Data.AppConfig.Apps
+	app3, app4 := apps[2], apps[3]
+
+	if domain := app3.Routes[0].Domain(); domain != "app.cloudfoundry" {
+		t.Fatalf("%s routes[0].Domain incorrect. Found: %+v", app3.Name, domain)
+	}
+	if domain := app4.Routes[0].Domain(); domain != "first.domain" {
+		t.Fatalf("%s routes[0].Domain incorrect. Found: %+v", app4.Name, domain)
+	}
+	if domain := app4.Routes[1].Domain(); domain != "first.domain" {
+		t.Fatalf("%s routes[1].Domain incorrect. Found: %+v", app4.Name, domain)
+	}
+	if domain := app4.Routes[2].Domain(); domain != "second.domain" {
+		t.Fatalf("%s routes[2].Domain incorrect. Found: %+v", app4.Name, domain)
+	}
+}
+
+// TestConfigEnvVar tests that environment variables within the given config resolve correctly.
+func TestConfigEnvVar(t *testing.T) {
 	confData := `---
 apps:
   enabled: true
@@ -173,7 +204,8 @@ apps:
 	}
 }
 
-func TestLoadResourceConfigSpaceNames(t *testing.T) {
+// TestSpaceNames tests that the correct space names are found with the given config.
+func TestSpaceNames(t *testing.T) {
 	conf := LoadResourceConfig([]byte(basicConfig))
 
 	spaces := conf.Data.SpaceConfig.Spaces
@@ -192,7 +224,8 @@ func TestLoadResourceConfigSpaceNames(t *testing.T) {
 	}
 }
 
-func TestLoadResourceConfigSpaceSSH(t *testing.T) {
+// TestSpaceSSH tests that the correct values for allow_ssh are found for the given config.
+func TestSpaceSSH(t *testing.T) {
 	conf := LoadResourceConfig([]byte(basicConfig))
 
 	spaces := conf.Data.SpaceConfig.Spaces


### PR DESCRIPTION
- Fix S1023: redundant 'return' statement (gosimple)
- Fix mnd: Magic number: 2, in <argument> detected (gomnd)
- Fix File is not 'gofmt'-ed with '-s' (gofmt)
- Fix cognitive complexity 16 of func '(*Detector).validateAppRoutes' is high (> 10) (gocognit)
- Fix cognitive complexity 13 of func '(*CFResourceCache).findRouteByURL' is high (> 10) (gocognit)
- Improve tests within resource_config_test.go
- Add golangci-lint config file
- Add golangci-lint GitHub action
