### PR TITLE
Easy cloud.gov deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Running watchtower behind a forward proxy is as simple as setting the
 
 ### Deploying as a cloud.gov app
 
-To deploy watchtower as a cloud.gov app, run:
+To deploy watchtower as a cloud.gov app using the [example manifest.yml file](manifest.yml), run:
 
 `cf push --var cf_user=<SPACE_AUDITOR_USER> --var cf_pass=<SPACE_AUDITOR_PASSWORD> --var watchtower_app_name=<WATCHTOWER_APP_NAME>`
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ in the config file provided to Watchtower to avoid false positives due to
 Running watchtower behind a forward proxy is as simple as setting the
 `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
 
+### Deploying as a cloud.gov app
+
+To deploy watchtower as a cloud.gov app, run:
+
+`cf push --var cf_user=<SPACE_AUDITOR_USER> --var cf_pass=<SPACE_AUDITOR_PASSWORD> --var watchtower_app_name=<WATCHTOWER_APP_NAME>`
+
 ## Watchtower Config
 Generic placeholder definitions:
 * `<boolean>`: a boolean that can take the values `true` or `false`
@@ -100,7 +106,7 @@ global:
   # interact with. Using the CF CLI, this value can be found with `cf api`.
   cloud_controller_url: <string> | default = ""
 apps:
-  # Whether to enable monitoring of CF Apps. Enabled=false will result in 
+  # Whether to enable monitoring of CF Apps. Enabled=false will result in
   # app-related metrics being the zero-value of the metric type.
   [ enabled: <boolean> | default = false ]
 
@@ -109,7 +115,7 @@ apps:
     [ - <cf_app_config> ... ]
 
 spaces:
-  # Whether to enable monitoring of CF Spaces. Enabled=false will result in 
+  # Whether to enable monitoring of CF Spaces. Enabled=false will result in
   # space-related metrics being the zero-value of the metric type.
   [ enabled: <boolean> | default = false ]
 
@@ -117,7 +123,7 @@ spaces:
   # access to all the spaces listed in the config, watchtower will list all
   # spaces it has access to and monitor any spaces with names matching config
   # entries found here. E.g. listing dev, test, and prod spaces here, but only
-  # giving Watchtower auditor permissions on the dev space would result in 
+  # giving Watchtower auditor permissions on the dev space would result in
   # monitoring only the dev space.
   resources:
     [ - <cf_space_config> ... ]

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@
 ---
 global:
   port: ${PORT}
-  refresh_interval: ${REFRESH_INTERVAL}
+  refresh_interval: 5m
   cloud_controller_url: ${CLOUD_CONTROLLER_URL}
 apps:
   enabled: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,9 @@
 # Example Config to demonstrate configuration options
 ---
+global:
+  port: ${PORT}
+  refresh_interval: ${REFRESH_INTERVAL}
+  cloud_controller_url: ${CLOUD_CONTROLLER_URL}
 apps:
   enabled: true
   resources:

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,14 +1,11 @@
 ---
 applications:
 - name: ((watchtower_app_name))
+  instances: 1
+  memory: 64m
   buildpacks:
     - go_buildpack
   env:
     CF_USER: ((cf_user))
     CF_PASS: ((cf_pass))
     CLOUD_CONTROLLER_URL: "https://api.fr.cloud.gov"
-    REFRESH_INTERVAL: 5m
-  processes:
-  - type: web
-    instances: 1
-    memory: 64m

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,14 @@
+---
+applications:
+- name: ((watchtower_app_name))
+  buildpacks:
+    - go_buildpack
+  env:
+    CF_USER: ((cf_user))
+    CF_PASS: ((cf_pass))
+    CLOUD_CONTROLLER_URL: "https://api.fr.cloud.gov"
+    REFRESH_INTERVAL: 5m
+  processes:
+  - type: web
+    instances: 1
+    memory: 64m


### PR DESCRIPTION
Easier deployment of watchtower as a cloud.gov app.

* Created manifest.yml file
* Added `global` entries to config.yaml, since relying on the defaults was not working. All three use Environment variables to allow them to work with any deployment situation